### PR TITLE
Add Regal for linting Rego

### DIFF
--- a/.github/workflows/opa-test.yaml
+++ b/.github/workflows/opa-test.yaml
@@ -18,3 +18,9 @@ jobs:
 
     - name: Run OPA Tests
       run: opa test internal/checker -v
+
+    - name: Setup Regal
+      uses: StyraInc/setup-regal@v0.2.0
+      with:
+        version: v0.11.0
+    - run: regal lint --format=github internal

--- a/internal/.regal/config.yaml
+++ b/internal/.regal/config.yaml
@@ -1,0 +1,45 @@
+rules:
+  bugs:
+    not-equals-in-loop:
+      # This is actually fine the way it's used here.
+      # Issue created in Regal for tracking:
+      # https://github.com/StyraInc/regal/issues/416
+      level: ignore
+  idiomatic:
+    custom-has-key-construct:
+      # A lot of these, where we could simply use `object.keys`
+      # and `in` instead
+      # https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct
+      level: ignore
+    use-in-operator:
+      # Same for this one — just use `in`
+      # https://docs.styra.com/regal/rules/idiomatic/custom-in-construct
+      level: ignore
+    no-defined-entrypoint:
+      # This is a good practice, but safe to ignore
+      # https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint
+      level: ignore
+  style:
+    # Style category safe to ignore, but good to follow modern conventions
+    # Address these as you see fit
+    # https://docs.styra.com/regal/category/style
+    external-reference:
+      level: ignore
+    file-length:
+      level: ignore
+    line-length:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+    rule-length:
+      level: ignore
+    use-assignment-operator:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      # https://docs.styra.com/regal/rules/testing/test-outside-test-package
+      level: ignore

--- a/internal/checker/kubernetes/rules/apiserver_cryptographic_ciphers.rego
+++ b/internal/checker/kubernetes/rules/apiserver_cryptographic_ciphers.rego
@@ -69,9 +69,7 @@ is_failed {
 	count(non_matching_ciphers) > 0
 }
 
-getContainerCommand[container] {
-    container := kubernetes.containers[_]
-}
+getContainerCommand[kubernetes.containers[_]]
 
 passed[result] {
     isValid

--- a/internal/checker/kubernetes/rules/apiserver_cryptographic_ciphers_test.rego
+++ b/internal/checker/kubernetes/rules/apiserver_cryptographic_ciphers_test.rego
@@ -10,9 +10,10 @@ test_apiserver_cryptographic_ciphers_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
+
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/auto_tls_test.rego
+++ b/internal/checker/kubernetes/rules/auto_tls_test.rego
@@ -10,9 +10,9 @@ test_auto_tls_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    { "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/cert_and_private_file.rego
+++ b/internal/checker/kubernetes/rules/cert_and_private_file.rego
@@ -35,6 +35,7 @@ hasContainersCommand {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag_0)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/client_cert_auth_test.rego
+++ b/internal/checker/kubernetes/rules/client_cert_auth_test.rego
@@ -10,9 +10,9 @@ test_client_cert_auth_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/controller_manager_bind_adress.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_bind_adress.rego
@@ -41,6 +41,7 @@ check {
 }
 
 getContainerCommand := result if {
+    some index, command_index
 	startswith(kubernetes.containers[index].command[command_index], flag)
     result := kubernetes.containers[index]
 } else := result if {

--- a/internal/checker/kubernetes/rules/controller_manager_bind_adress_test.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_bind_adress_test.rego
@@ -10,9 +10,10 @@ test_controller_manager_bind_adress_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
+
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_credential.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_credential.rego
@@ -50,6 +50,7 @@ check {
 }
 
 getContainerCommand := result if {
+    some index, command_index
 	startswith(kubernetes.containers[index].command[command_index], flag)
     result := kubernetes.containers[index]
 } else := result if {

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_credential_test.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_credential_test.rego
@@ -10,9 +10,9 @@ test_controller_manager_service_account_credential_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_private_key.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_private_key.rego
@@ -54,6 +54,7 @@ has_container_command(key, flag, argument) {
 }
 
 getContainerCommand := result if {
+    some index, command_index
 	startswith(kubernetes.containers[index].command[command_index], flag)
     result := kubernetes.containers[index]
 } else := result if {

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_private_key_test.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_private_key_test.rego
@@ -10,9 +10,9 @@ test_controller_manager_service_account_private_key_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_root_ca.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_root_ca.rego
@@ -54,6 +54,7 @@ has_container_command(key, flag, argument) {
 }
 
 getContainerCommand := result if {
+    some index, command_index
 	startswith(kubernetes.containers[index].command[command_index], flag)
     result := kubernetes.containers[index]
 } else := result if {

--- a/internal/checker/kubernetes/rules/controller_manager_service_account_root_ca_test.rego
+++ b/internal/checker/kubernetes/rules/controller_manager_service_account_root_ca_test.rego
@@ -10,9 +10,9 @@ test_controller_manager_service_account_root_ca_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/deny_NET_RAW.rego
+++ b/internal/checker/kubernetes/rules/deny_NET_RAW.rego
@@ -17,13 +17,13 @@ resource = kubernetes.resource
 check {
     kubernetes.is_psp
     requiredDropCapabilities := kubernetes.spec.requiredDropCapabilities
-    regex.match("\\bALL\\b", requiredDropCapabilities)
+    regex.match(`\bALL\b`, requiredDropCapabilities)
 }
 
 check {
     kubernetes.is_psp
     requiredDropCapabilities := kubernetes.spec.requiredDropCapabilities
-    regex.match("\\bNET_RAW\\b", requiredDropCapabilities)
+    regex.match(`\bNET_RAW\b`, requiredDropCapabilities)
 }
 
 passed[result] {

--- a/internal/checker/kubernetes/rules/encryption_provider_config_test.rego
+++ b/internal/checker/kubernetes/rules/encryption_provider_config_test.rego
@@ -10,9 +10,9 @@ test_encryption_provider_config_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": args }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": args}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/etcd_ca_file_test.rego
+++ b/internal/checker/kubernetes/rules/etcd_ca_file_test.rego
@@ -10,9 +10,9 @@ test_etcd_ca_file_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": args }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": args}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/event_capture.rego
+++ b/internal/checker/kubernetes/rules/event_capture.rego
@@ -34,11 +34,13 @@ hasCommand(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/event_capture_test.rego
+++ b/internal/checker/kubernetes/rules/event_capture_test.rego
@@ -10,9 +10,9 @@ test_event_capture_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/hostname_override.rego
+++ b/internal/checker/kubernetes/rules/hostname_override.rego
@@ -32,6 +32,7 @@ hasContainersCommand {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/hostname_override_test.rego
+++ b/internal/checker/kubernetes/rules/hostname_override_test.rego
@@ -11,9 +11,9 @@ test_hostname_override_failed {
 	count(result) == 1
 }
 
-input_data(params) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": params }])
-}
+input_data(params) := json.patch(json_data, [
+    { "op": "replace", "path": "spec/containers/0/command/1", "value": params }
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/kubelet_cryptographic_ciphers.rego
+++ b/internal/checker/kubernetes/rules/kubelet_cryptographic_ciphers.rego
@@ -68,9 +68,7 @@ is_failed {
 	count(non_matching_ciphers) > 0
 }
 
-getContainerCommand[container] {
-    container := kubernetes.containers[_]
-}
+getContainerCommand[kubernetes.containers[_]]
 
 passed[result] {
     isValid

--- a/internal/checker/kubernetes/rules/kubelet_cryptographic_ciphers_test.rego
+++ b/internal/checker/kubernetes/rules/kubelet_cryptographic_ciphers_test.rego
@@ -10,9 +10,9 @@ test_kubelet_cryptographic_ciphers_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/kubernetes_properties.rego
+++ b/internal/checker/kubernetes/rules/kubernetes_properties.rego
@@ -84,11 +84,10 @@ is_psp {
     kind = "PodSecurityPolicy"
 }
 
-pod_containers(pod) = available_containers {
-	available_containers = pod.spec.containers
-}
+pod_containers(pod) := pod.spec.containers
 
 containers[container] {
+	some pod
 	podTemplates[pod]
 	available_containers = pod_containers(pod)
 	container = available_containers[_]
@@ -123,18 +122,17 @@ podTemplates[pod] {
 }
 
 volumes[volume] {
+	some pod
 	podTemplates[pod]
 	volume = pod.spec.volumes[_]
 }
 
-filtered_rules(apiGroups, resources, verbs) = filtered_rules {
-	filtered_rules := [ r |
-		r := rules[_]
-		r.apiGroups[_] == apiGroups[_]
-		r.resources[_] == resources[_]
-		r.verbs[_] == verbs[_]
-	]
-}
+filtered_rules(apiGroups, resources, verbs) := [ r |
+	r := rules[_]
+	r.apiGroups[_] == apiGroups[_]
+	r.resources[_] == resources[_]
+	r.verbs[_] == verbs[_]
+]
 
 has_container_command(key, flag, argument) {
 	split({ r | r := key[_]; startswith(r, flag) }[_], "=")[1] == argument
@@ -144,9 +142,7 @@ has_attribute(key, value) {
   _ = key[value]
 }
 
-array_to_set(val) = value {
-	value := { l | l := val[_] } 
-}
+array_to_set(val) := { l | l := val[_] }
 
 is_apiserver(container){
 	has_attribute(container, "command")

--- a/internal/checker/kubernetes/rules/make_iptables_util_chains.rego
+++ b/internal/checker/kubernetes/rules/make_iptables_util_chains.rego
@@ -29,11 +29,13 @@ hasCommand(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/make_iptables_util_chains_test.rego
+++ b/internal/checker/kubernetes/rules/make_iptables_util_chains_test.rego
@@ -10,9 +10,10 @@ test_make_iptables_util_chains_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
+
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/minimize_admission_containers.rego
+++ b/internal/checker/kubernetes/rules/minimize_admission_containers.rego
@@ -18,7 +18,7 @@ check {
     container := input.spec.containers[_]
     kubernetes.has_attribute(container.securityContext.capabilities, "drop")
     drop := container.securityContext.capabilities.drop[_]
-    regex.match("(?i)\\ball\\b", drop)
+    regex.match(`(?i)\ball\b`, drop)
 }
 
 

--- a/internal/checker/kubernetes/rules/peer_client_cert_auth_test.rego
+++ b/internal/checker/kubernetes/rules/peer_client_cert_auth_test.rego
@@ -10,9 +10,9 @@ test_peer_client_cert_auth_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/args/0", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/args/0", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/protect_kernel_defaults.rego
+++ b/internal/checker/kubernetes/rules/protect_kernel_defaults.rego
@@ -30,11 +30,13 @@ hasCommand(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/rbac/impersonate_permissions_test.rego
+++ b/internal/checker/kubernetes/rules/rbac/impersonate_permissions_test.rego
@@ -1,6 +1,6 @@
 package lib.kubernetes.CB_K8S_024
 
-#Test case for 'Cluster Role'
+# Test case for 'Cluster Role'
 
 test_clusterrole_passed {
             result := passed with input as{
@@ -55,7 +55,7 @@ test_clusterrole_failed {
 }
 
 
-#Test case for 'Role'
+# Test case for 'Role'
 
 test_role_passed {
             result := passed with input as{

--- a/internal/checker/kubernetes/rules/rbac/webhook_configurations.rego
+++ b/internal/checker/kubernetes/rules/rbac/webhook_configurations.rego
@@ -3,7 +3,7 @@
 # description: "Ensure to minimize the permission of validating or mutating admission webhook configurations from ClusterRoles."
 # scope: package
 # related_resources:
-# - https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/   
+# - https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 # custom:
 #   id: CB_K8S_011
 #   severity: HIGH
@@ -26,9 +26,7 @@ is_failed {
     count(kubernetes.filtered_rules(api_groups, resources, verbs)) > 0
 }
 
-getFilteredRules[rules] {
-    rules := kubernetes.filtered_rules(api_groups, resources, [""])
-}
+getFilteredRules[kubernetes.filtered_rules(api_groups, resources, [""])]
 
 passed[result] {
     is_valid

--- a/internal/checker/kubernetes/rules/rbac/wildcard_roles.rego
+++ b/internal/checker/kubernetes/rules/rbac/wildcard_roles.rego
@@ -21,16 +21,19 @@ is_valid {
 }
 
 is_failed[rule] {
+    some rule_index, index
     kubernetes.rules[rule_index].apiGroups[index] == wildcard
     rule := kubernetes.rules[rule_index]
 }
 
 is_failed[rule] {
+    some rule_index, index
     kubernetes.rules[rule_index].resources[index] == wildcard
     rule := kubernetes.rules[rule_index]
 }
 
 is_failed[rule] {
+    some rule_index, index
     kubernetes.rules[rule_index].verbs[index] == wildcard
     rule := kubernetes.rules[rule_index]
 }

--- a/internal/checker/kubernetes/rules/read_only_port.rego
+++ b/internal/checker/kubernetes/rules/read_only_port.rego
@@ -30,11 +30,13 @@ hasReadOnlyPort(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/rotate_certificates.rego
+++ b/internal/checker/kubernetes/rules/rotate_certificates.rego
@@ -3,7 +3,7 @@
 # description: "The --rotate-certificates setting causes the kubelet to rotate its client certificates by creating new CSRs as its existing credentials expire"
 # scope: package
 # related_resources:
-# - https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ 
+# - https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
 # custom:
 #   id: CB_K8S_052
 #   severity: HIGH
@@ -31,11 +31,13 @@ hasReadOnlyPort(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/rotate_certificates_test.rego
+++ b/internal/checker/kubernetes/rules/rotate_certificates_test.rego
@@ -11,9 +11,9 @@ test_make_iptables_util_chains_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/rotate_kubelet_server_cert.rego
+++ b/internal/checker/kubernetes/rules/rotate_kubelet_server_cert.rego
@@ -56,6 +56,7 @@ has_container_command(key, flag, argument) {
 }
 
 getContainerCommand := result if {
+    some index, command_index
 	startswith(kubernetes.containers[index].command[command_index], flag)
     result := kubernetes.containers[index]
 } else := result if {

--- a/internal/checker/kubernetes/rules/rotate_kubelet_server_cert_test.rego
+++ b/internal/checker/kubernetes/rules/rotate_kubelet_server_cert_test.rego
@@ -10,9 +10,9 @@ test_rotate_kubelet_server_cert_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/streaming_connnection_idle_timeout.rego
+++ b/internal/checker/kubernetes/rules/streaming_connnection_idle_timeout.rego
@@ -30,11 +30,13 @@ hasCommand(container) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/terminated_pod_gc_threshold.rego
+++ b/internal/checker/kubernetes/rules/terminated_pod_gc_threshold.rego
@@ -36,11 +36,13 @@ hasCommand(commands) {
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].command[command_index], flag)
     container := kubernetes.containers[index]
 }
 
 getContainerCommand[container] {
+    some index, command_index
     startswith(kubernetes.containers[index].args[command_index], flag)
     container := kubernetes.containers[index]
 }

--- a/internal/checker/kubernetes/rules/terminated_pod_gc_threshold_test.rego
+++ b/internal/checker/kubernetes/rules/terminated_pod_gc_threshold_test.rego
@@ -9,9 +9,9 @@ test_terminated_pod_gc_threshold_failed {
 	count(result) == 1
 }
 
-input_data(args) = patch {
-    patch := json.patch(json_data, [{ "op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args]) }])
-}
+input_data(args) := json.patch(json_data, [
+    {"op": "replace", "path": "spec/containers/0/command/1", "value": concat("=", [flag, args])}
+])
 
 json_data := {
                 "apiVersion": "v1",

--- a/internal/checker/kubernetes/rules/verify_service_account_key_file.rego
+++ b/internal/checker/kubernetes/rules/verify_service_account_key_file.rego
@@ -29,7 +29,7 @@ check[container]{
 	startswith(commands, "--service-account-key-file")
 	contains(commands, "=")
 	args := split(commands, "=")[1]
-	regex.match("^(\\/?[a-zA-Z0-9_\\-]+)+\\.pem$", args)
+	regex.match(`^(\/?[a-zA-Z0-9_\-]+)+\.pem$`, args)
 }
 
 serviceAccountKeyInvalid[container]{

--- a/internal/checker/terraform/rules/aws/aws_lambda_function_secret.rego
+++ b/internal/checker/terraform/rules/aws/aws_lambda_function_secret.rego
@@ -18,22 +18,22 @@ has_attribute(key, value) {
 }
 
 checkRegex(value){
-	regex.match("[A-Z0-9]{20}", value)
+	regex.match(`[A-Z0-9]{20}`, value)
 
 }
 
 checkRegex(value){
-	regex.match("[a-zA-Z0-9/+]{40}", value)
+	regex.match(`[a-zA-Z0-9/+]{40}`, value)
 }
 
 resource [resource]{
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 resource [resource]{
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 fail[block] {
   block := input[_]

--- a/internal/checker/terraform/rules/aws/aws_mq_broker_current_mqbroker_version.rego
+++ b/internal/checker/terraform/rules/aws/aws_mq_broker_current_mqbroker_version.rego
@@ -9,7 +9,7 @@
 #   severity: LOW
 package lib.terraform.CB_TFAWS_209
 
-import future.keywords.in 
+import future.keywords.in
 
 supportedResources := ["aws_mq_broker", "aws_mq_configuration"]
 
@@ -21,18 +21,18 @@ isvalid(block){
 resource [resource]{
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 resource [resource]{
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 
 pass[resource] {
     resource := input[_]
     isvalid(resource)
     resource.Attributes.engine_type == "ActiveMQ"
-    regex.match("(\\d+\\.\\d+\\.\\d+)", resource.Attributes.engine_version)
+    regex.match(`(\d+\.\d+\.\d+)`, resource.Attributes.engine_version)
     engineVersion := resource.Attributes.engine_version
     major := split(engineVersion, ".")[0]
     minor := split(engineVersion, ".")[1]
@@ -46,7 +46,7 @@ pass[resource] {
     resource := input[_]
     isvalid(resource)
     resource.Attributes.engine_type == "ActiveMQ"
-    regex.match("(\\d+\\.\\d+\\.\\d+)", resource.Attributes.engine_version)
+    regex.match(`(\d+\.\d+\.\d+)`, resource.Attributes.engine_version)
     engineVersion := resource.Attributes.engine_version
     major := split(engineVersion, ".")[0]
     minor := split(engineVersion, ".")[1]
@@ -59,7 +59,7 @@ pass[resource] {
     resource := input[_]
     isvalid(resource)
     resource.Attributes.engine_type == "RabbitMQ"
-    regex.match("(\\d+\\.\\d+\\.\\d+)", resource.Attributes.engine_version)
+    regex.match(`(\d+\.\d+\.\d+)`, resource.Attributes.engine_version)
     engineVersion := resource.Attributes.engine_version
     major := split(engineVersion, ".")[0]
     minor := split(engineVersion, ".")[1]
@@ -73,7 +73,7 @@ pass[resource] {
     resource := input[_]
     isvalid(resource)
     resource.Attributes.engine_type == "RabbitMQ"
-    regex.match("(\\d+\\.\\d+\\.\\d+)", resource.Attributes.engine_version)
+    regex.match(`(\d+\.\d+\.\d+)`, resource.Attributes.engine_version)
     engineVersion := resource.Attributes.engine_version
     major := split(engineVersion, ".")[0]
     minor := split(engineVersion, ".")[1]

--- a/internal/checker/terraform/rules/aws/aws_secret_allow_pattern.rego
+++ b/internal/checker/terraform/rules/aws/aws_secret_allow_pattern.rego
@@ -17,19 +17,19 @@ isvalid(block){
 resource [resource]{
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 resource [resource]{
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 checkRegex(block){
-	regex.match("[A-Z0-9]{20}", block.Attributes.access_key)
+	regex.match(`[A-Z0-9]{20}`, block.Attributes.access_key)
 
 }
 
 checkRegex(block){
-	regex.match("[a-zA-Z0-9/+]{40}", block.Attributes.secret_key)
+	regex.match(`[a-zA-Z0-9/+]{40}`, block.Attributes.secret_key)
 }
 
 fail[resource] {

--- a/internal/checker/terraform/rules/aws/enable_dynamodb_pitr.rego
+++ b/internal/checker/terraform/rules/aws/enable_dynamodb_pitr.rego
@@ -17,14 +17,15 @@ isvalid(block){
 resource[resource] {
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
-resource[resource] { 
+resource[resource] {
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 pass[resource]{
+    some index
     resource := input[_]
 	isvalid(resource)
     resource.Blocks[index].Type == "point_in_time_recovery"
@@ -47,4 +48,4 @@ failed[result] {
     block := fail[_]
 	result := { "message": "'aws_dynamodb_table' 'point_in_time_recovery' must be set to true.",
                 "snippet": block }
-} 
+}

--- a/internal/checker/terraform/rules/aws/iam/aws_iam_role_deny_iam_roles_users_groups_utilizing_aws_administratoraccess_policy.rego
+++ b/internal/checker/terraform/rules/aws/iam/aws_iam_role_deny_iam_roles_users_groups_utilizing_aws_administratoraccess_policy.rego
@@ -19,12 +19,12 @@ isvalid(block){
 resource[resource] {
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
-resource[resource] { 
+resource[resource] {
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 fail[resource] {
     resource := input[_]
@@ -36,7 +36,7 @@ fail[resource] {
 
 ends_with_admin_access(arns) {
     arn := arns[_]
-    regex.match(".+/AdministratorAccess$", arn)
+    regex.match(`.+/AdministratorAccess$`, arn)
 }
 
 pass[block] {
@@ -55,4 +55,4 @@ failed[result] {
     block := fail[_]
 	result := { "message": "Utilizing AWS AdministratorAccess policy must be denied for IAM roles, users, and groups.",
                 "snippet": block }
-} 
+}

--- a/internal/checker/terraform/rules/aws/verify_aws_Lambda_function_configured inside_vpc_test.rego
+++ b/internal/checker/terraform/rules/aws/verify_aws_Lambda_function_configured inside_vpc_test.rego
@@ -32,7 +32,7 @@ test_aws_lamda_function_configured_inside_vpc {
 	count(result) == 1
 }
 
-test_aws_lamda_function_configured_inside_vpc {
+test_aws_lamda_function_configured_inside_vpc_failed {
 	result := failed with input as [{
 		"Type": "resource",
 		"Labels": [

--- a/internal/checker/terraform/rules/aws/verify_cloudfront_distribution_encryption.rego
+++ b/internal/checker/terraform/rules/aws/verify_cloudfront_distribution_encryption.rego
@@ -17,14 +17,15 @@ isvalid(block){
 resource[resource] {
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
-resource[resource] { 
+resource[resource] {
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 fail[resource]{
+    some index
     resource := input[_]
 	isvalid(resource)
     resource.Blocks[index].Type == "default_cache_behavior"
@@ -32,6 +33,7 @@ fail[resource]{
 }
 
 fail[resource]{
+    some index
     resource := input[_]
 	isvalid(resource)
     resource.Blocks[index].Type == "ordered_cache_behavior"
@@ -54,4 +56,4 @@ failed[result] {
     block := fail[_]
 	result := { "message": "'aws_cloudfront_distribution' 'default_cache_behavior' and 'ordered_cache_behavior' should not use 'allow-all'.",
                 "snippet": block }
-} 
+}

--- a/internal/checker/terraform/rules/aws/verify_elb_policy_uses_secure_protocols.rego
+++ b/internal/checker/terraform/rules/aws/verify_elb_policy_uses_secure_protocols.rego
@@ -18,11 +18,11 @@ isvalid(block){
 resource [resource]{
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 resource [resource]{
     block := fail[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
 fail[resource]{
     resource := input[_]
@@ -34,13 +34,9 @@ fail[resource]{
     not is_false(block.Attributes.value)
 }
 
-is_false(value) {
-    value == false
-}
+is_false(false)
 
-is_false(value) {
-    value == "false"
-}
+is_false("false")
 
 fail[resource]{
     resource := input[_]

--- a/internal/checker/terraform/rules/aws/verify_kinesis_firehost_delivery_stream_uses_cmk_test.rego
+++ b/internal/checker/terraform/rules/aws/verify_kinesis_firehost_delivery_stream_uses_cmk_test.rego
@@ -34,7 +34,7 @@ test_verify_kinesis_firehost_delivery_stream_uses_cmk_passed {
 	count(result) == 1
 }
 
-test_verify_kinesis_firehost_delivery_stream_uses_cmk_passed {
+test_verify_kinesis_firehost_delivery_stream_uses_cmk_failed {
 	result := failed with input as [
 									{
 									"Type": "resource",

--- a/internal/checker/terraform/rules/oci/verify_administrator_user_not_associated_with_api_key.rego
+++ b/internal/checker/terraform/rules/oci/verify_administrator_user_not_associated_with_api_key.rego
@@ -34,7 +34,7 @@ group[resource] {
 group_membership[resource] {
 	resource := input[_]
     resource.Labels[_] == "oci_identity_user_group_membership"
-    
+
     resource.Attributes.user_id == concat(".",[concat(".", users[_].Labels),"id"])
     resource.Attributes.group_id == concat(".",[concat(".", group[_].Labels),"id"])
 }
@@ -54,9 +54,9 @@ admin_check(resource) := true if {
 resource[resource] {
     block := pass[_]
 	resource := concat(".", block.Labels)
-} 
+}
 
-resource[resource] { 
+resource[resource] {
     block := fail[_]
 	resource := concat(".", block.Labels)
 }
@@ -68,6 +68,7 @@ pass[block] {
 }
 
 fail[resource] {
+    some index, i
     api_key[_].Attributes.user_id == group_membership[_].Attributes.user_id
     api_users := split(api_key[_].Attributes.user_id, ".")[_]
     api_users != "oci_identity_user"
@@ -88,4 +89,4 @@ failed[result] {
     block := fail[_]
 	result := { "message": "An Administrator user associated with API keys was found.",
                 "snippet": block }
-} 
+}


### PR DESCRIPTION
Hey there brainiacs! 👋😃 This PR introduces [Regal](https://github.com/styrainc/regal) for linting the Rego included in this project. A lot of Rego to process here, and quite a few reported violations. I've added a Regal configuration file to ignore a bunch of rules for the time being, and fixed some of the more low-hanging fruits as part of the PR.

The rules addressed in this PR:

* [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)
* [no-whitespace-comment](https://docs.styra.com/regal/rules/style/no-whitespace-comment)
* [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)
* [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)
* [equals-pattern-matching](https://docs.styra.com/regal/rules/idiomatic/equals-pattern-matching)
* [identically-named-tests](https://docs.styra.com/regal/rules/testing/identically-named-tests)

See the config file provided for a list of the rules ignored, where I've tried to annotate the rules with some short explanations, and pointers to the docs.

I've also added steps to lint Rego as part of pushes/PRs.

Let me know what you think!