### PR TITLE
feat: Implement rule for verifying that security rules do not have 's…

### DIFF
--- a/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any.rego
+++ b/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any.rego
@@ -1,0 +1,50 @@
+# METADATA
+# title: "Verify that security rules do not have both 'source_addresses' and 'destination_addresses' set to 'any'"
+# description: "Confirm that security rules do not specify 'source_addresses' and 'destination_addresses' as 'any' simultaneously to avoid overly permissive configurations."
+# scope: package
+# related_resources:
+# - https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/security_policy.html
+# custom:
+#   id: CB_TFPAN_007
+#   severity: MEDIUM
+package lib.terraform.CB_TFPAN_007
+
+import future.keywords.in
+
+isvalid(block) {
+	supported_resources := ["panos_security_policy", "panos_security_rule_group"]
+	block.Type == "resource"
+	some label in block.Labels
+	label in supported_resources
+}
+
+fail[block] {
+	some block in input
+	isvalid(block)
+	some inner_block in block.Blocks
+	inner_block.Type == "rule"
+	"any" in inner_block.Attributes.destination_addresses
+	"any" in inner_block.Attributes.source_addresses
+}
+
+pass[block] {
+	some block in input
+	isvalid(block)
+	not fail[block]
+}
+
+passed[result] {
+	some block in pass
+	result := {
+		"message": "The 'source_addresses' and 'destination_addresses' attributes are not set to 'any'.",
+		"snippet": block,
+	}
+}
+
+failed[result] {
+	some block in fail
+	result := {
+		"message": "The 'source_addresses' and 'destination_addresses' attributes must not be set to 'any'.",
+		"snippet": block,
+	}
+}

--- a/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any_test.rego
+++ b/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any_test.rego
@@ -1,0 +1,67 @@
+package lib.terraform.CB_TFPAN_007
+
+test_panos_security_policy_services_not_set_to_any_passed {
+	result := passed with input as [{
+		"Type": "resource",
+		"Labels": [
+			"panos_security_policy",
+			"example",
+		],
+		"Attributes": {"name": "example-policy"},
+		"Blocks": [{
+			"Type": "rule",
+			"Labels": [],
+			"Attributes": {
+				"action": "allow",
+				"destination_addresses": ["internet"],
+				"source_addresses": ["trusted_network"],
+			},
+			"Blocks": [],
+			"line_range": {
+				"endLine": 8,
+				"startLine": 4,
+			},
+		}],
+		"line_range": {
+			"endLine": 11,
+			"startLine": 1,
+		},
+	}]
+	count(result) == 1
+}
+
+test_panos_security_policy_services_not_set_to_any_failed {
+	result := failed with input as [{
+		"Type": "resource",
+		"Labels": [
+			"panos_security_policy",
+			"example",
+		],
+		"Attributes": {"name": "example-policy"},
+		"Blocks": [{
+			"Type": "rule",
+			"Labels": [],
+			"Attributes": {
+				"action": "allow",
+				"destination_addresses": [
+					"internet",
+					"any",
+				],
+				"source_addresses": [
+					"trusted_network",
+					"any",
+				],
+			},
+			"Blocks": [],
+			"line_range": {
+				"endLine": 8,
+				"startLine": 4,
+			},
+		}],
+		"line_range": {
+			"endLine": 11,
+			"startLine": 1,
+		},
+	}]
+	count(result) == 1
+}

--- a/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any_test.rego
+++ b/internal/checker/terraform/rules/pan/panos_security_policy_source_destination_add_restrict_any_test.rego
@@ -1,6 +1,6 @@
 package lib.terraform.CB_TFPAN_007
 
-test_panos_security_policy_services_not_set_to_any_passed {
+test_panos_security_policy_source_destination_add_restrict_any_passed {
 	result := passed with input as [{
 		"Type": "resource",
 		"Labels": [
@@ -30,7 +30,7 @@ test_panos_security_policy_services_not_set_to_any_passed {
 	count(result) == 1
 }
 
-test_panos_security_policy_services_not_set_to_any_failed {
+test_panos_security_policy_source_destination_add_restrict_any_failed {
 	result := failed with input as [{
 		"Type": "resource",
 		"Labels": [


### PR DESCRIPTION
…ource_addresses' and 'destination_addresses' both containing values of 'any'